### PR TITLE
added CTNP removal, hardcoded Copyright section content

### DIFF
--- a/xml_docx_stylechecks/lib/doc_prepare.py
+++ b/xml_docx_stylechecks/lib/doc_prepare.py
@@ -492,7 +492,7 @@ def docPrepare(report_dict):
     # # # Commenting this out until we have alternate padding in place for these items.
     # # # See Asana task: https://app.asana.com/0/405970099375554/453275643539715
     # now that we captured their contents (where needed), we can get rid of Nonprinting head paras
-    # report_dict = rmNonPrintingHeads(report_dict, doc_root, cfg.nonprintingheads)
+    report_dict = rmNonPrintingHeads(report_dict, doc_root, cfg.nonprintingheads)
 
     # autonumber contents for chapter, Appendix, Part
     report_dict = lxml_utils.autoNumberSectionParaContent(report_dict, sectionnames, cfg.autonumber_sections, doc_root)

--- a/xml_docx_stylechecks/shared_utils/lxml_utils.py
+++ b/xml_docx_stylechecks/shared_utils/lxml_utils.py
@@ -201,7 +201,10 @@ def getContentsForSectionStart(sectionbegin_para, doc_root, headingstyles, secti
         stylename = pneighbors['nextstyle']
     # set content equal to the content of the first heading-styled para in the section
     #   if heading para is chapnumber or partnumber, join it with the following Chap Title / Part title para(s?)
-    if stylename in headingstyles:
+    #   (manually setting Copyright section's name)
+    if sectionname == cfg.copyrightsection_stylename:
+        newcontent = 'Copyright'
+    elif stylename in headingstyles:
         if stylename == cfg.chapnumstyle or stylename == cfg.partnumstyle:
             pneighbors = getNeighborParas(tmp_para)
             if (stylename == cfg.chapnumstyle and pneighbors['nextstyle'] == cfg.chaptitlestyle) or (stylename == cfg.partnumstyle and pneighbors['nextstyle'] == cfg.parttitlestyle):


### PR DESCRIPTION
small changes re: Nonprinting head cleanup for validator, hardcoding sectionstart para content for converter (for Copyright section)