### PR TITLE
excluding deleted comment objects from comment xml files for 'log-cal…

### DIFF
--- a/xml_docx_stylechecks/shared_utils/lxml_utils.py
+++ b/xml_docx_stylechecks/shared_utils/lxml_utils.py
@@ -402,15 +402,15 @@ def findParasWithStyle(stylename, doc_root):
         paras.append(para)
     return paras
 
-# once all changes havebeen made, call this to add location info for users to the changelog dicts
+# once all changes have been made, call this to add location info for users to the changelog dicts
 def calcLocationInfoForLog(report_dict, root, section_names, alt_roots=[]):
     logger.info("calculating para_index numbers for all para_ids in 'report_dict'")
     try:
         # make sure we have contents in the dict
         if report_dict:
             for category, entries in report_dict.iteritems():
-                # exclude hard-coded 'marker' attributes for validator_main
-                if category != 'validator_py_complete' and category != 'percent_styled':
+                # exclude hard-coded 'marker' attributes for validator_main; also skipping deleted objects from commentxml files
+                if category != 'validator_py_complete' and category != 'percent_styled' and 'deleted_objects-comments-comments' not in category:
                     for entry in entries:
                         for key in entry.keys():
                             if key == "para_id":


### PR DESCRIPTION
…clation' function; is moot and wastes time

Came up with one particular document which contained 1000's of empty comment objects in comment xml files, which added 20 minutes to runtime during lxm_utils.calcLocationInfoForLog function.